### PR TITLE
ci: hard code host entry for bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,7 @@ matrix:
   fast_finish: true
   allow_failures:
   - env: IMAGE_ARCH=armel
-  - env: IMAGE_ARCH=mips
   - env: IMAGE_ARCH=mips64el
-  - env: IMAGE_ARCH=mipsel
   - env: IMAGE_ARCH=ppc64el
   - env: IMAGE_ARCH=s390x
 
@@ -58,6 +56,7 @@ before_install:
   sudo docker run --detach --interactive --tty \
     --name test_container \
     -v ${TRAVIS_BUILD_DIR%${TRAVIS_REPO_SLUG}}:${TRAVIS_BUILD_DIR%${TRAVIS_REPO_SLUG}} \
+    --add-host dl.bintray.com:$(nslookup dl.bintray.com | grep -m1 -A1 Name: | grep Address: | awk '{print $2}') \
     laarid/devel:${IMAGE_ARCH} \
     /bin/bash
 


### PR DESCRIPTION
Although there has been an hard code step in https://github.com/laarid/docker/pull/10 , Docker regenerates /etc/hosts when creating the container. As a result, specifying an additional host entry is a must.

Closes: #5