### PR TITLE
ci: split process into multiple build flavors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,26 @@ language: cpp
 
 env:
   matrix:
-  - IMAGE_ARCH=amd64
-  - IMAGE_ARCH=arm64
-  - IMAGE_ARCH=armel
-  - IMAGE_ARCH=armhf
-  - IMAGE_ARCH=i386
-  - IMAGE_ARCH=mips
-  - IMAGE_ARCH=mips64el
-  - IMAGE_ARCH=mipsel
-  - IMAGE_ARCH=ppc64el
-  - IMAGE_ARCH=s390x
+  - BUILD_FLAVOR=amd64_deb
+  - BUILD_FLAVOR=amd64_distcheck
+  - BUILD_FLAVOR=arm64_deb
+  - BUILD_FLAVOR=arm64_distcheck
+  - BUILD_FLAVOR=armel_deb
+  - BUILD_FLAVOR=armel_distcheck
+  - BUILD_FLAVOR=armhf_deb
+  - BUILD_FLAVOR=armhf_distcheck
+  - BUILD_FLAVOR=i386_deb
+  - BUILD_FLAVOR=i386_distcheck
+  - BUILD_FLAVOR=mips_deb
+  - BUILD_FLAVOR=mips_distcheck
+  - BUILD_FLAVOR=mips64el_deb
+  - BUILD_FLAVOR=mips64el_distcheck
+  - BUILD_FLAVOR=mipsel_deb
+  - BUILD_FLAVOR=mipsel_distcheck
+  - BUILD_FLAVOR=ppc64el_deb
+  - BUILD_FLAVOR=ppc64el_distcheck
+  - BUILD_FLAVOR=s390x_deb
+  - BUILD_FLAVOR=s390x_distcheck
   global:
   - DOCKER_EXEC_ROOT="sudo docker exec --interactive --tty --user root test_container"
   - DOCKER_EXEC="sudo docker exec --interactive --tty test_container"
@@ -28,7 +38,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-  - env: IMAGE_ARCH=mips64el
+  - env: BUILD_FLAVOR=mips64el_deb
 
 branches:
   only:
@@ -47,14 +57,14 @@ cache:
 - apt
 
 before_install:
-- sudo docker pull laarid/devel:${IMAGE_ARCH}
+- sudo docker pull laarid/devel:${BUILD_FLAVOR%_*}
 - sudo docker images
 - |
   sudo docker run --detach --interactive --tty \
     --name test_container \
     -v ${TRAVIS_BUILD_DIR%${TRAVIS_REPO_SLUG}}:${TRAVIS_BUILD_DIR%${TRAVIS_REPO_SLUG}} \
     --add-host dl.bintray.com:$(nslookup dl.bintray.com | grep -m1 -A1 Name: | grep Address: | awk '{print $2}') \
-    laarid/devel:${IMAGE_ARCH} \
+    laarid/devel:${BUILD_FLAVOR%_*} \
     /bin/bash
 
 install:
@@ -62,8 +72,14 @@ install:
 - ${DOCKER_EXEC_ROOT} mk-build-deps -i -s sudo -t 'apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y --allow-unauthenticated' ${TRAVIS_BUILD_DIR}/debian/control
 
 script:
-- ${DOCKER_EXEC} /bin/sh -c "cd ${TRAVIS_BUILD_DIR}; debuild --preserve-env --preserve-envvar PATH --set-envvar=DEB_BUILD_OPTIONS=nocheck -i -us -uc -b"
-- ${DOCKER_EXEC} /bin/sh -c "cd ${TRAVIS_BUILD_DIR}; make -C build -j $(nproc) distcheck"
+- case "${BUILD_FLAVOR#*_}" in
+    deb)
+      ${DOCKER_EXEC} /bin/sh -c "cd ${TRAVIS_BUILD_DIR}; debuild --preserve-env --preserve-envvar PATH --set-envvar=DEB_BUILD_OPTIONS=nocheck -i -us -uc -b";
+      ;;
+    distcheck)
+      ${DOCKER_EXEC} /bin/sh -c "cd ${TRAVIS_BUILD_DIR}; (mkdir build && cd build && autoreconf -i --warnings=all .. && ../configure --build=\$(dpkg-architecture -qDEB_BUILD_GNU_TYPE) --host=\$(dpkg-architecture -qDEB_HOST_GNU_TYPE) --disable-dependency-tracking && make -j \$(nproc) .gitignore distcheck)";
+      ;;
+  esac
 - git status | grep 'working tree clean'
 
 before_deploy:
@@ -91,6 +107,7 @@ deploy:
     secure: "qZmynoFS3xYdDANotC/PtUNobxs/vakivZ7YxSZsHjSH2KI/9AaLLHqm57Gjh9DgvNu84PnsBnlb8H2aWkwiZuuJpYyLOFV2hUE384oLuOb/84N2P3R9uf+ru0+AjavzrMH2mNQpG6+XS3KNT08a7nBcWTrNSFsV2QGkhb3+BUQnv/SMAP1b3nh/0AcbRe9yGsE9jeQDG6hmZjDH+DjbApIdZ2WWfd4fAyFgqZHoGsN4yOwr41BwVBbXKTxyC1DQxstGazyq1ezNdNTJixVMuHW7qliHuKcUMYeC0PNNGoKI7pRkfI3q0SarkOiVqaOtwWP8u1Y0GZ+5ZLWcN2xmjHH/v4MgvpoIkVUxAto4cWEN7EfAATzV1IvpVxq2EPOgjCxOfqdLI9Qv/paJ7a7AOb/g+dV8brTRP1RJ2OPMrVdt6MKINRLjs0GCXtjkszEwdjv57L/9BgHg0WCQRGMrPMAFKxSlG9H5jfj0hlhMAOgQBsoUmacpdboPiF8fXOMrE9T3CiWmO3KZERbfahUzGj55DTxNt9XaFy7cYPZFEAw6c6t1mtAUyirPaMEZ/UjZHC1tqChJB4+qT+uLAVICq4ihUy7ZA0PUfT/WfyIjxQpXG+yet1tdlXbIOmvgShpPyo1Sc0VUawqFUJlFcLNeYfx2OtDUvggAt5dQLQd2G+8="
   on:
     tags: true
+    condition: ${BUILD_FLAVOR#*_} = deb
 
 notifications:
   slack:

--- a/Makefile.am
+++ b/Makefile.am
@@ -83,6 +83,7 @@ include $(srcdir)/libsparse/Android.mk
 include $(srcdir)/libcutils/Android.mk
 
 # Stage 0-2: depends on any of above packages
+include $(srcdir)/base/Android.mk
 include $(srcdir)/libdiskconfig/Android.mk
 include $(srcdir)/libnetutils/Android.mk
 include $(srcdir)/libsuspend/Android.mk

--- a/Makefile.am
+++ b/Makefile.am
@@ -86,6 +86,7 @@ include $(srcdir)/libion/Android.mk
 # Stage 0-2: depends on any of above packages
 include $(srcdir)/base/Android.mk
 include $(srcdir)/libdiskconfig/Android.mk
+include $(srcdir)/logwrapper/Android.mk
 include $(srcdir)/libnetutils/Android.mk
 include $(srcdir)/libsuspend/Android.mk
 include $(srcdir)/libsysutils/Android.mk

--- a/Makefile.am
+++ b/Makefile.am
@@ -81,6 +81,7 @@ include $(srcdir)/libsparse/Android.mk
 
 # Stage 0-1: depends on any of above packages
 include $(srcdir)/libcutils/Android.mk
+include $(srcdir)/libion/Android.mk
 
 # Stage 0-2: depends on any of above packages
 include $(srcdir)/base/Android.mk

--- a/base/Android.mk
+++ b/base/Android.mk
@@ -14,96 +14,69 @@
 # limitations under the License.
 #
 
-LOCAL_PATH := $(call my-dir)
+lib_LTLIBRARIES += \
+	%reldir%/libandroid-base.la
 
-libbase_src_files := \
-    file.cpp \
-    stringprintf.cpp \
-    strings.cpp \
+%canon_reldir%_libandroid_base_la_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(BIONIC_CFLAGS) \
+	-I$(srcdir)/%reldir%/include
+%canon_reldir%_libandroid_base_la_CXXFLAGS = \
+	$(AM_CXXFLAGS) \
+	-Wextra
+%canon_reldir%_libandroid_base_la_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	$(libtool_opts)
+%canon_reldir%_libandroid_base_la_LIBADD = \
+	$(BIONIC_LIBS) \
+	liblog/libandroid-log.la
+%canon_reldir%_libandroid_base_la_SOURCES = \
+	%reldir%/file.cpp \
+	%reldir%/logging.cpp \
+	%reldir%/stringprintf.cpp \
+	%reldir%/strings.cpp
 
-libbase_test_src_files := \
-    file_test.cpp \
-    stringprintf_test.cpp \
-    strings_test.cpp \
-    test_main.cpp \
-    test_utils.cpp \
+%canon_reldir%_libandroid_base_incdir = $(androidincdir)/base
+%canon_reldir%_libandroid_base_inc_HEADERS = \
+	%reldir%/include/base/file.h \
+	%reldir%/include/base/logging.h \
+	%reldir%/include/base/macros.h \
+	%reldir%/include/base/memory.h \
+	%reldir%/include/base/stringprintf.h \
+	%reldir%/include/base/strings.h
 
-libbase_cppflags := \
-    -Wall \
-    -Wextra \
-    -Werror \
+pkgconfig_DATA += \
+	%reldir%/android-base-$(SYSTEMCORE_API_VERSION).pc
 
-# Device
-# ------------------------------------------------------------------------------
-include $(CLEAR_VARS)
-LOCAL_MODULE := libbase
-LOCAL_CLANG := true
-LOCAL_SRC_FILES := $(libbase_src_files) logging.cpp
-LOCAL_C_INCLUDES := $(LOCAL_PATH)/include
-LOCAL_CPPFLAGS := $(libbase_cppflags)
-LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/include
-LOCAL_STATIC_LIBRARIES := libcutils
-LOCAL_MULTILIB := both
-include $(BUILD_STATIC_LIBRARY)
+if HAVE_GTEST
+check_PROGRAMS += \
+	%reldir%/libbase_test
 
-include $(CLEAR_VARS)
-LOCAL_MODULE := libbase
-LOCAL_CLANG := true
-LOCAL_WHOLE_STATIC_LIBRARIES := libbase
-LOCAL_SHARED_LIBRARIES := liblog
-LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/include
-LOCAL_SHARED_LIBRARIES := libcutils
-LOCAL_MULTILIB := both
-include $(BUILD_SHARED_LIBRARY)
+TESTS += \
+	%reldir%/libbase_test
 
-# Host
-# ------------------------------------------------------------------------------
-include $(CLEAR_VARS)
-LOCAL_MODULE := libbase
-LOCAL_SRC_FILES := $(libbase_src_files)
-ifneq ($(HOST_OS),windows)
-    LOCAL_SRC_FILES += logging.cpp
+%canon_reldir%_libbase_test_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(BIONIC_CFLAGS) \
+	$(GTEST_CPPFLAGS) \
+	-I$(srcdir)/%reldir%/include
+%canon_reldir%_libbase_test_LDADD = \
+	$(BIONIC_LIBS) \
+	liblog/libandroid-log.la \
+	libcutils/libandroid-cutils.la \
+	%reldir%/libandroid-base.la \
+	$(GTEST_LIBS)
+%canon_reldir%_libbase_test_DEPENDENCIES = \
+	liblog/libandroid-log.la \
+	libcutils/libandroid-cutils.la \
+	%reldir%/libandroid-base.la \
+	$(GTEST_LIBS)
+%canon_reldir%_libbase_test_SOURCES = \
+	%reldir%/file_test.cpp \
+	%reldir%/logging.cpp \
+	%reldir%/stringprintf_test.cpp \
+	%reldir%/strings_test.cpp \
+	%reldir%/test_main.cpp \
+	%reldir%/test_utils.cpp \
+	%reldir%/test_utils.h
 endif
-LOCAL_C_INCLUDES := $(LOCAL_PATH)/include
-LOCAL_CPPFLAGS := $(libbase_cppflags)
-LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/include
-LOCAL_STATIC_LIBRARIES := libcutils
-LOCAL_MULTILIB := both
-include $(BUILD_HOST_STATIC_LIBRARY)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := libbase
-LOCAL_WHOLE_STATIC_LIBRARIES := libbase
-LOCAL_SHARED_LIBRARIES := liblog
-LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/include
-LOCAL_STATIC_LIBRARIES := libcutils
-LOCAL_MULTILIB := both
-include $(BUILD_HOST_SHARED_LIBRARY)
-
-# Tests
-# ------------------------------------------------------------------------------
-include $(CLEAR_VARS)
-LOCAL_MODULE := libbase_test
-LOCAL_CLANG := true
-LOCAL_SRC_FILES := $(libbase_test_src_files) logging_test.cpp
-LOCAL_C_INCLUDES := $(LOCAL_PATH)
-LOCAL_CPPFLAGS := $(libbase_cppflags)
-LOCAL_SHARED_LIBRARIES := libbase
-LOCAL_MULTILIB := both
-LOCAL_MODULE_STEM_32 := $(LOCAL_MODULE)32
-LOCAL_MODULE_STEM_64 := $(LOCAL_MODULE)64
-include $(BUILD_NATIVE_TEST)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := libbase_test
-LOCAL_SRC_FILES := $(libbase_test_src_files)
-ifneq ($(HOST_OS),windows)
-    LOCAL_SRC_FILES += logging_test.cpp
-endif
-LOCAL_C_INCLUDES := $(LOCAL_PATH)
-LOCAL_CPPFLAGS := $(libbase_cppflags)
-LOCAL_SHARED_LIBRARIES := libbase
-LOCAL_MULTILIB := both
-LOCAL_MODULE_STEM_32 := $(LOCAL_MODULE)32
-LOCAL_MODULE_STEM_64 := $(LOCAL_MODULE)64
-include $(BUILD_HOST_NATIVE_TEST)

--- a/base/android-base-0.0.pc.in
+++ b/base/android-base-0.0.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: android-base-@SYSTEMCORE_API_VERSION@
+Description: Android System Core Libraries - base
+Version: @VERSION@
+Requires.private: android-log-@SYSTEMCORE_API_VERSION@, android-cutils-@SYSTEMCORE_API_VERSION@
+Libs: -L${libdir} -landroid-base
+Cflags: -I${includedir}/android/system-core-@SYSTEMCORE_API_VERSION@

--- a/base/include/base/logging.h
+++ b/base/include/base/logging.h
@@ -47,7 +47,6 @@ typedef std::function<void(LogId, LogSeverity, const char*, const char*,
 extern void StderrLogger(LogId, LogSeverity, const char*, const char*,
                          unsigned int, const char*);
 
-#ifdef __ANDROID__
 // We expose this even though it is the default because a user that wants to
 // override the default log buffer will have to construct this themselves.
 class LogdLogger {
@@ -60,7 +59,6 @@ class LogdLogger {
  private:
   LogId default_log_id_;
 };
-#endif
 
 // Configure logging based on ANDROID_LOG_TAGS environment variable.
 // We need to parse a string that looks like

--- a/base/logging.cpp
+++ b/base/logging.cpp
@@ -37,7 +37,10 @@
 #include "cutils/threads.h"
 
 // Headers for LogMessage::LogLine.
+#if 0
+/* FIXME: https://github.com/laarid/package_android-system-core/issues/19 */
 #include <android/set_abort_message.h>
+#endif
 #include "cutils/log.h"
 
 namespace android {
@@ -263,7 +266,10 @@ LogMessage::~LogMessage() {
 
   // Abort if necessary.
   if (data_->GetSeverity() == FATAL) {
+#if 0
+    /* FIXME: https://github.com/laarid/package_android-system-core/issues/19 */
     android_set_abort_message(msg.c_str());
+#endif
     abort();
   }
 }

--- a/base/logging_test.cpp
+++ b/base/logging_test.cpp
@@ -25,11 +25,7 @@
 
 #include <gtest/gtest.h>
 
-#ifdef __ANDROID__
 #define HOST_TEST(suite, name) TEST(suite, DISABLED_ ## name)
-#else
-#define HOST_TEST(suite, name) TEST(suite, name)
-#endif
 
 class CapturedStderr {
  public:

--- a/configure.ac
+++ b/configure.ac
@@ -305,6 +305,7 @@ AC_CONFIG_FILES([
   base/android-base-$SYSTEMCORE_API_VERSION.pc
   libcutils/android-cutils-$SYSTEMCORE_API_VERSION.pc
   libdiskconfig/android-diskconfig-$SYSTEMCORE_API_VERSION.pc
+  libion/android-ion-$SYSTEMCORE_API_VERSION.pc
   liblog/android-log-$SYSTEMCORE_API_VERSION.pc
   libmincrypt/android-mincrypt-$SYSTEMCORE_API_VERSION.pc
   libnetutils/android-netutils-$SYSTEMCORE_API_VERSION.pc

--- a/configure.ac
+++ b/configure.ac
@@ -300,6 +300,10 @@ AC_SUBST([GTEST_SRCDIR])
 AC_LANG_POP()
 AM_CONDITIONAL([HAVE_GTEST], [test "x${with_gtest}" != xno])
 
+dnl Whether should we run ION unit tests
+AC_CHECK_FILE([/dev/ion])
+AM_CONDITIONAL([HAVE_DEV_ION], [test "x${c_cv_file_dev_ion}" = xyes])
+
 AC_CONFIG_FILES([
   Makefile
   base/android-base-$SYSTEMCORE_API_VERSION.pc

--- a/configure.ac
+++ b/configure.ac
@@ -317,5 +317,6 @@ AC_CONFIG_FILES([
   libsuspend/android-suspend-$SYSTEMCORE_API_VERSION.pc
   libsysutils/android-sysutils-$SYSTEMCORE_API_VERSION.pc
   libusbhost/android-usbhost-$SYSTEMCORE_API_VERSION.pc
+  logwrapper/android-logwrap-$SYSTEMCORE_API_VERSION.pc
 ])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -302,6 +302,7 @@ AM_CONDITIONAL([HAVE_GTEST], [test "x${with_gtest}" != xno])
 
 AC_CONFIG_FILES([
   Makefile
+  base/android-base-$SYSTEMCORE_API_VERSION.pc
   libcutils/android-cutils-$SYSTEMCORE_API_VERSION.pc
   libdiskconfig/android-diskconfig-$SYSTEMCORE_API_VERSION.pc
   liblog/android-log-$SYSTEMCORE_API_VERSION.pc

--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@
 #   systemcore_interface_revision = 0
 m4_define([systemcore_major_version], [0])
 m4_define([systemcore_minor_version], [0])
-m4_define([systemcore_micro_version], [9])
+m4_define([systemcore_micro_version], [10])
 m4_define([systemcore_interface_revision], [0])
 m4_define([systemcore_api_version], [systemcore_major_version.0])
 m4_define([systemcore_release_number], [systemcore_major_version])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+android-system-core (0.0.10) stretch; urgency=low
+
+  * ci: split process into multiple build flavors
+  * build libandroid-base
+  * build libandroid-ion
+  * build libandroid-logwrap, logwrapper
+  * mincrypt: build unit tests
+
+ -- You-Sheng Yang <vicamo@gmail.com>  Sat, 7 Jan 2017 11:13:24 +0800
+
 android-system-core (0.0.9+b1) stretch; urgency=low
 
   * disable bintray version sign and enable override

--- a/debian/control
+++ b/debian/control
@@ -201,6 +201,41 @@ Depends: ${shlibs:Depends},
 Description: Android libdiskconfig
  This package contains libdiskconfig built from Android platform/system/core.
 
+Package: logwrapper
+Priority: extra
+Section: misc
+Architecture: any
+Multi-Arch: no
+Depends: ${misc:Depends},
+         ${shlibs:Depends}
+Description: Android logwrapper
+ This package contains logwrapper.
+
+Package: libandroid-logwrap0-dev
+Priority: extra
+Section: libdevel
+Architecture: any
+Multi-Arch: same
+Depends: libandroid-logwrap0 (= ${binary:Version}),
+         libandroid-cutils0-dev,
+         libandroid-log0-dev,
+         ${misc:Depends}
+Description: Android liblogwrap - development
+ This package contains liblogwrap built from Android platform/system/core.
+ .
+ This package contains the development files.
+
+Package: libandroid-logwrap0
+Priority: extra
+Section: libs
+Architecture: any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${shlibs:Depends},
+         ${misc:Depends}
+Description: Android liblogwrap
+ This package contains liblogwrap built from Android platform/system/core.
+
 Package: libandroid-netutils0-dev
 Priority: extra
 Section: libdevel

--- a/debian/control
+++ b/debian/control
@@ -126,6 +126,31 @@ Depends: ${shlibs:Depends},
 Description: Android libcutils
  This package contains libcutils built from Android platform/system/core.
 
+Package: libandroid-base0-dev
+Priority: extra
+Section: libdevel
+Architecture: any
+Multi-Arch: same
+Depends: libandroid-base0 (= ${binary:Version}),
+         libandroid-cutils0-dev,
+         libandroid-log0-dev,
+         ${misc:Depends}
+Description: Android libbase - development
+ This package contains libbase built from Android platform/system/core.
+ .
+ This package contains the development files.
+
+Package: libandroid-base0
+Priority: extra
+Section: libs
+Architecture: any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${shlibs:Depends},
+         ${misc:Depends}
+Description: Android libbase
+ This package contains libbase built from Android platform/system/core.
+
 Package: libandroid-diskconfig0-dev
 Priority: extra
 Section: libdevel

--- a/debian/control
+++ b/debian/control
@@ -126,6 +126,31 @@ Depends: ${shlibs:Depends},
 Description: Android libcutils
  This package contains libcutils built from Android platform/system/core.
 
+Package: libandroid-ion0-dev
+Priority: extra
+Section: libdevel
+Architecture: any
+Multi-Arch: same
+Depends: libandroid-ion0 (= ${binary:Version}),
+         libandroid-log0-dev,
+         libandroid-bionic0-dev,
+         ${misc:Depends}
+Description: Android libion - development
+ This package contains libion built from Android platform/system/core.
+ .
+ This package contains the development files.
+
+Package: libandroid-ion0
+Priority: extra
+Section: libs
+Architecture: any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${shlibs:Depends},
+         ${misc:Depends}
+Description: Android libion
+ This package contains libion built from Android platform/system/core.
+
 Package: libandroid-base0-dev
 Priority: extra
 Section: libdevel

--- a/debian/libandroid-base0-dev.install
+++ b/debian/libandroid-base0-dev.install
@@ -1,0 +1,4 @@
+usr/include/android/system-core-*/base
+usr/lib/*/libandroid-base.a
+usr/lib/*/libandroid-base.so
+usr/lib/*/pkgconfig/android-base-*.pc

--- a/debian/libandroid-base0.install
+++ b/debian/libandroid-base0.install
@@ -1,0 +1,1 @@
+usr/lib/*/libandroid-base.so.*

--- a/debian/libandroid-base0.lintian-overrides
+++ b/debian/libandroid-base0.lintian-overrides
@@ -1,0 +1,2 @@
+# Only mips variants have this error. See https://github.com/laarid/package_android-system-core/issues/3
+libandroid-base0 [mips mipsel mips64el] binary: shlib-without-PT_GNU_STACK-section usr/lib*/libandroid-base.so.*

--- a/debian/libandroid-distkconfig0.lintian-overrides
+++ b/debian/libandroid-distkconfig0.lintian-overrides
@@ -1,2 +1,0 @@
-# Only mips variants have this error. See https://github.com/laarid/package_android-system-core/issues/3
-libandroid-diskconfig0 [mips mipsel mips64el] binary: shlib-without-PT_GNU_STACK-section usr/lib*/libandroid-diskconfig.so.*

--- a/debian/libandroid-ion0-dev.install
+++ b/debian/libandroid-ion0-dev.install
@@ -1,0 +1,6 @@
+usr/include/android/system-core-*/ion
+usr/include/linux/ion.h
+usr/include/linux/ion_test.h
+usr/lib/*/libandroid-ion.a
+usr/lib/*/libandroid-ion.so
+usr/lib/*/pkgconfig/android-ion-*.pc

--- a/debian/libandroid-ion0.install
+++ b/debian/libandroid-ion0.install
@@ -1,0 +1,1 @@
+usr/lib/*/libandroid-ion.so.*

--- a/debian/libandroid-ion0.lintian-overrides
+++ b/debian/libandroid-ion0.lintian-overrides
@@ -1,0 +1,2 @@
+# Only mips variants have this error. See https://github.com/laarid/package_android-system-core/issues/3
+libandroid-ion0 [mips mipsel mips64el] binary: shlib-without-PT_GNU_STACK-section usr/lib*/libandroid-ion.so.*

--- a/debian/libandroid-logwrap0-dev.install
+++ b/debian/libandroid-logwrap0-dev.install
@@ -1,0 +1,4 @@
+usr/include/android/system-core-*/logwrap
+usr/lib/*/libandroid-logwrap.a
+usr/lib/*/libandroid-logwrap.so
+usr/lib/*/pkgconfig/android-logwrap-*.pc

--- a/debian/libandroid-logwrap0.install
+++ b/debian/libandroid-logwrap0.install
@@ -1,0 +1,1 @@
+usr/lib/*/libandroid-logwrap.so.*

--- a/debian/libandroid-logwrap0.lintian-overrides
+++ b/debian/libandroid-logwrap0.lintian-overrides
@@ -1,0 +1,2 @@
+# Only mips variants have this error. See https://github.com/laarid/package_android-system-core/issues/3
+libandroid-logwrap0 [mips mipsel mips64el] binary: shlib-without-PT_GNU_STACK-section usr/lib*/libandroid-logwrap.so.*

--- a/debian/logwrapper.install
+++ b/debian/logwrapper.install
@@ -1,0 +1,1 @@
+usr/bin/logwrapper

--- a/gtest.mk
+++ b/gtest.mk
@@ -7,6 +7,11 @@ libgtest_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	$(GTEST_CPPFLAGS) \
 	-I $(GTEST_SRCDIR)
+libgtest_la_CXXFLAGS = \
+	$(AM_CXXFLAGS) \
+	$(PTHREAD_CFLAGS)
+libgtest_la_LIBADD = \
+	$(PTHREAD_LIBS)
 nodist_libgtest_la_SOURCES = \
 	$(top_builddir)/gtest-all.cc
 
@@ -16,6 +21,11 @@ $(top_builddir)/gtest-all.cc: $(top_builddir)
 libgtest_main_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	$(GTEST_CPPFLAGS)
+libgtest_main_la_CXXFLAGS = \
+	$(AM_CXXFLAGS) \
+	$(PTHREAD_CFLAGS)
+libgtest_main_la_LIBADD = \
+	$(PTHREAD_LIBS)
 nodist_libgtest_main_la_SOURCES = \
 	$(top_builddir)/gtest_main.cc
 

--- a/libcutils/threads.c
+++ b/libcutils/threads.c
@@ -16,33 +16,7 @@
 
 #include "cutils/threads.h"
 
-// For gettid.
-#if defined(__APPLE__)
-#include "AvailabilityMacros.h"  // For MAC_OS_X_VERSION_MAX_ALLOWED
-#include <stdint.h>
-#include <stdlib.h>
-#include <sys/syscall.h>
-#include <sys/time.h>
-#include <unistd.h>
-#elif defined(__linux__) && !defined(__ANDROID__)
-#include <syscall.h>
-#include <unistd.h>
-#elif defined(_WIN32)
-#include <windows.h>
-#endif
-
-// No definition needed for Android because we'll just pick up bionic's copy.
-#ifndef __ANDROID__
-pid_t gettid() {
-#if defined(__APPLE__)
-  return syscall(SYS_thread_selfid);
-#elif defined(__linux__)
-  return syscall(__NR_gettid);
-#elif defined(_WIN32)
-  return GetCurrentThreadId();
-#endif
-}
-#endif  // __ANDROID__
+#include <bionic/bionic.h> // For gettid.
 
 #if !defined(_WIN32)
 

--- a/libion/Android.mk
+++ b/libion/Android.mk
@@ -1,22 +1,42 @@
-LOCAL_PATH := $(call my-dir)
+lib_LTLIBRARIES += \
+	%reldir%/libandroid-ion.la
 
-include $(CLEAR_VARS)
-LOCAL_SRC_FILES := ion.c
-LOCAL_MODULE := libion
-LOCAL_MODULE_TAGS := optional
-LOCAL_SHARED_LIBRARIES := liblog
-LOCAL_C_INCLUDES := $(LOCAL_PATH)/include $(LOCAL_PATH)/kernel-headers
-LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/include $(LOCAL_PATH)/kernel-headers
-LOCAL_CFLAGS := -Werror
-include $(BUILD_SHARED_LIBRARY)
+%canon_reldir%_libandroid_ion_la_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(BIONIC_CFLAGS) \
+	-I$(srcdir)/%reldir%/include \
+	-I$(srcdir)/%reldir%/kernel-headers
+%canon_reldir%_libandroid_ion_la_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	$(libtool_opts)
+%canon_reldir%_libandroid_ion_la_LIBADD = \
+	liblog/libandroid-log.la
+%canon_reldir%_libandroid_ion_la_SOURCES = \
+	%reldir%/ion.c
 
-include $(CLEAR_VARS)
-LOCAL_SRC_FILES := ion.c ion_test.c
-LOCAL_MODULE := iontest
-LOCAL_MODULE_TAGS := optional tests
-LOCAL_C_INCLUDES := $(LOCAL_PATH)/include $(LOCAL_PATH)/kernel-headers
-LOCAL_SHARED_LIBRARIES := liblog
-LOCAL_CFLAGS := -Werror
-include $(BUILD_EXECUTABLE)
+%canon_reldir%_libandroid_ion_incdir = $(androidincdir)/ion
+%canon_reldir%_libandroid_ion_inc_HEADERS = \
+	%reldir%/include/ion/ion.h
 
-include $(call first-makefiles-under,$(LOCAL_PATH))
+%canon_reldir%_libandroid_ion_kernel_incdir = $(includedir)/linux
+%canon_reldir%_libandroid_ion_kernel_inc_HEADERS = \
+	%reldir%/kernel-headers/linux/ion.h \
+	%reldir%/kernel-headers/linux/ion_test.h
+
+noinst_PROGRAMS += \
+	%reldir%/iontest
+%canon_reldir%_iontest_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(BIONIC_CFLAGS) \
+	-I$(srcdir)/%reldir%/include \
+	-I$(srcdir)/%reldir%/kernel-headers
+%canon_reldir%_iontest_LDADD = \
+	liblog/libandroid-log.la \
+	%reldir%/libandroid-ion.la
+%canon_reldir%_iontest_SOURCES = \
+	%reldir%/ion_test.c
+
+pkgconfig_DATA += \
+	%reldir%/android-ion-$(SYSTEMCORE_API_VERSION).pc
+
+include %reldir%/tests/Android.mk

--- a/libion/android-ion-0.0.pc.in
+++ b/libion/android-ion-0.0.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: android-ion-@SYSTEMCORE_API_VERSION@
+Description: Android System Core Libraries - ion
+Version: @VERSION@
+Requires.private: android-log-@SYSTEMCORE_API_VERSION@
+Libs: -L${libdir} -landroid-ion
+Cflags: -I${includedir}/android/system-core-@SYSTEMCORE_API_VERSION@

--- a/libion/ion_test.c
+++ b/libion/ion_test.c
@@ -150,7 +150,7 @@ void ion_share_test()
         cmsg->cmsg_level = SOL_SOCKET;
         cmsg->cmsg_type = SCM_RIGHTS;
         cmsg->cmsg_len = CMSG_LEN(sizeof(int));
-        *(int *)CMSG_DATA(cmsg) = share_fd;
+        memcpy(CMSG_DATA(cmsg), &share_fd, sizeof(share_fd));
         /* send the fd */
         printf("master? [%10s] should be [master]\n", ptr);
         printf("master sending msg 1\n");
@@ -191,7 +191,7 @@ void ion_share_test()
             printf("no cmsg rcvd in child");
             return;
         }
-        recv_fd = *(int*)CMSG_DATA(cmsg);
+        memcpy(&recv_fd, CMSG_DATA(cmsg), sizeof(recv_fd));
         if (recv_fd < 0) {
             printf("could not get recv_fd from socket");
             return;

--- a/libion/tests/Android.mk
+++ b/libion/tests/Android.mk
@@ -14,19 +14,34 @@
 # limitations under the License.
 #
 
-LOCAL_PATH:= $(call my-dir)
+if HAVE_GTEST
+check_PROGRAMS += \
+	%reldir%/ion-unit-tests
 
-include $(CLEAR_VARS)
-LOCAL_MODULE := ion-unit-tests
-LOCAL_CFLAGS += -g -Wall -Werror -std=gnu++11 -Wno-missing-field-initializers
-LOCAL_SHARED_LIBRARIES += libion
-LOCAL_C_INCLUDES := $(LOCAL_PATH)/../kernel-headers
-LOCAL_SRC_FILES := \
-	ion_test_fixture.cpp \
-	allocate_test.cpp \
-	formerly_valid_handle_test.cpp \
-	invalid_values_test.cpp \
-	map_test.cpp \
-	device_test.cpp \
-	exit_test.cpp
-include $(BUILD_NATIVE_TEST)
+TESTS += \
+	%reldir%/ion-unit-tests
+
+%canon_reldir%_ion_unit_tests_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(GTEST_CPPFLAGS) \
+	-I$(srcdir)/libion/include \
+	-I$(srcdir)/libion/kernel-headers
+%canon_reldir%_ion_unit_tests_CXXFLAGS = \
+	$(AM_CXXFLAGS) \
+	-g -Wno-missing-field-initializers
+%canon_reldir%_ion_unit_tests_LDADD = \
+	libion/libandroid-ion.la \
+	$(GTEST_LIBS)
+%canon_reldir%_ion_unit_tests_DEPENDENCIES = \
+	libion/libandroid-ion.la \
+	$(GTEST_LIBS)
+%canon_reldir%_ion_unit_tests_SOURCES = \
+	%reldir%/ion_test_fixture.cpp \
+	%reldir%/ion_test_fixture.h \
+	%reldir%/allocate_test.cpp \
+	%reldir%/formerly_valid_handle_test.cpp \
+	%reldir%/invalid_values_test.cpp \
+	%reldir%/map_test.cpp \
+	%reldir%/device_test.cpp \
+	%reldir%/exit_test.cpp
+endif

--- a/libion/tests/Android.mk
+++ b/libion/tests/Android.mk
@@ -18,8 +18,10 @@ if HAVE_GTEST
 check_PROGRAMS += \
 	%reldir%/ion-unit-tests
 
+if HAVE_DEV_ION
 TESTS += \
 	%reldir%/ion-unit-tests
+endif
 
 %canon_reldir%_ion_unit_tests_CPPFLAGS = \
 	$(AM_CPPFLAGS) \

--- a/libion/tests/device_test.cpp
+++ b/libion/tests/device_test.cpp
@@ -18,6 +18,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/ioctl.h>
 
 #include <linux/ion_test.h>
 

--- a/libmincrypt/Android.mk
+++ b/libmincrypt/Android.mk
@@ -17,3 +17,5 @@ lib_LTLIBRARIES += \
 
 pkgconfig_DATA += \
 	%reldir%/android-mincrypt-$(SYSTEMCORE_API_VERSION).pc
+
+include $(srcdir)/%reldir%/test/Android.mk

--- a/libmincrypt/test/Android.mk
+++ b/libmincrypt/test/Android.mk
@@ -1,15 +1,35 @@
 # Copyright 2013 The Android Open Source Project
 
-LOCAL_PATH := $(call my-dir)
+if HAVE_GTEST
+check_PROGRAMS += \
+	%reldir%/rsa_test \
+	%reldir%/ecdsa_test
 
-include $(CLEAR_VARS)
-LOCAL_MODULE := rsa_test
-LOCAL_SRC_FILES := rsa_test.c
-LOCAL_STATIC_LIBRARIES := libmincrypt
-include $(BUILD_HOST_NATIVE_TEST)
+TESTS += \
+	%reldir%/rsa_test \
+	%reldir%/ecdsa_test
 
-include $(CLEAR_VARS)
-LOCAL_MODULE := ecdsa_test
-LOCAL_SRC_FILES := ecdsa_test.c
-LOCAL_STATIC_LIBRARIES := libmincrypt
-include $(BUILD_HOST_NATIVE_TEST)
+%canon_reldir%_rsa_test_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(GTEST_CPPFLAGS)
+%canon_reldir%_rsa_test_LDADD = \
+	libmincrypt/libandroid-mincrypt.la \
+	$(GTEST_LIBS)
+%canon_reldir%_rsa_test_DEPENDENCIES = \
+	libmincrypt/libandroid-mincrypt.la \
+	$(GTEST_LIBS)
+%canon_reldir%_rsa_test_SOURCES = \
+	%reldir%/rsa_test.c
+
+%canon_reldir%_ecdsa_test_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(GTEST_CPPFLAGS)
+%canon_reldir%_ecdsa_test_LDADD = \
+	libmincrypt/libandroid-mincrypt.la \
+	$(GTEST_LIBS)
+%canon_reldir%_ecdsa_test_DEPENDENCIES = \
+	libmincrypt/libandroid-mincrypt.la \
+	$(GTEST_LIBS)
+%canon_reldir%_ecdsa_test_SOURCES = \
+	%reldir%/ecdsa_test.c
+endif

--- a/logwrapper/Android.mk
+++ b/logwrapper/Android.mk
@@ -1,37 +1,36 @@
-LOCAL_PATH:= $(call my-dir)
+lib_LTLIBRARIES += \
+	%reldir%/libandroid-logwrap.la
 
-include $(CLEAR_VARS)
+%canon_reldir%_libandroid_logwrap_la_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(BIONIC_CFLAGS) \
+	-I$(srcdir)/%reldir%/include
+%canon_reldir%_libandroid_logwrap_la_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	$(libtool_opts)
+%canon_reldir%_libandroid_logwrap_la_LIBADD = \
+	liblog/libandroid-log.la \
+	libcutils/libandroid-cutils.la
+%canon_reldir%_libandroid_logwrap_la_SOURCES = \
+	%reldir%/logwrap.c
 
-# ========================================================
-# Static library
-# ========================================================
-include $(CLEAR_VARS)
-LOCAL_MODULE := liblogwrap
-LOCAL_SRC_FILES := logwrap.c
-LOCAL_SHARED_LIBRARIES := libcutils liblog
-LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/include
-LOCAL_C_INCLUDES := $(LOCAL_PATH)/include
-LOCAL_CFLAGS := -Werror
-include $(BUILD_STATIC_LIBRARY)
+%canon_reldir%_libandroid_logwrap_incdir = $(androidincdir)/logwrap
+%canon_reldir%_libandroid_logwrap_inc_HEADERS = \
+	%reldir%/include/logwrap/logwrap.h
 
-# ========================================================
-# Shared library
-# ========================================================
-include $(CLEAR_VARS)
-LOCAL_MODULE := liblogwrap
-LOCAL_SHARED_LIBRARIES := libcutils liblog
-LOCAL_WHOLE_STATIC_LIBRARIES := liblogwrap
-LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/include
-LOCAL_C_INCLUDES := $(LOCAL_PATH)/include
-LOCAL_CFLAGS := -Werror
-include $(BUILD_SHARED_LIBRARY)
+bin_PROGRAMS += \
+	%reldir%/logwrapper
 
-# ========================================================
-# Executable
-# ========================================================
-include $(CLEAR_VARS)
-LOCAL_SRC_FILES:= logwrapper.c
-LOCAL_MODULE := logwrapper
-LOCAL_STATIC_LIBRARIES := liblog liblogwrap libcutils
-LOCAL_CFLAGS := -Werror
-include $(BUILD_EXECUTABLE)
+%canon_reldir%_logwrapper_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(BIONIC_CFLAGS) \
+	-I$(srcdir)/%reldir%/include
+%canon_reldir%_logwrapper_LDADD = \
+	liblog/libandroid-log.la \
+	libcutils/libandroid-cutils.la \
+	%reldir%/libandroid-logwrap.la
+%canon_reldir%_logwrapper_SOURCES = \
+	%reldir%/logwrapper.c
+
+pkgconfig_DATA += \
+	%reldir%/android-logwrap-$(SYSTEMCORE_API_VERSION).pc

--- a/logwrapper/android-logwrap-0.0.pc.in
+++ b/logwrapper/android-logwrap-0.0.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: android-logwrap-@SYSTEMCORE_API_VERSION@
+Description: Android System Core Libraries - logwrap
+Version: @VERSION@
+Requires.private: android-log-@SYSTEMCORE_API_VERSION@
+Libs: -L${libdir} -landroid-logwrap
+Cflags: -I${includedir}/android/system-core-@SYSTEMCORE_API_VERSION@

--- a/logwrapper/logwrap.c
+++ b/logwrapper/logwrap.c
@@ -311,7 +311,7 @@ static int parent(const char *tag, int parent_read, pid_t pid,
     bool found_child = false;
     char tmpbuf[256];
 
-    log_info.btag = basename(tag);
+    log_info.btag = basename((char *)tag);
     if (!log_info.btag) {
         log_info.btag = (char*) tag;
     }


### PR DESCRIPTION
It takes too much time to build debs and distcheck in the same travis job, and this causes timeouts and job termination. This change splits the process so that we may build more stage 0 packages.