### PR TITLE
ci: disable bintray version sign and enable override

### DIFF
--- a/debian/bintray.json.in
+++ b/debian/bintray.json.in
@@ -19,7 +19,7 @@
         "desc": "v@BINTRAY_VERSION@ release",
         "released": "@BINTRAY_RELEASE_DATE@",
         "vcs_tag": "v@BINTRAY_VERSION@",
-        "gpgSign": true
+        "gpgSign": false
     },
 
     "files": [{
@@ -28,7 +28,8 @@
         "matrixParams": {
             "deb_distribution": "@BINTRAY_SUITE@",
             "deb_component": "@BINTRAY_COMPONENT@",
-            "deb_architecture": "@BINTRAY_ARCH@"
+            "deb_architecture": "@BINTRAY_ARCH@",
+            "override": 1
         }
     }],
     "publish": true

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+android-system-core (0.0.9+b1) stretch; urgency=low
+
+  * disable bintray version sign and enable override
+
+ -- You-Sheng Yang <vicamo@gmail.com>  Fri, 6 Jan 2017 9:29:17 +0800
+
 android-system-core (0.0.9) stretch; urgency=medium
 
   * build against bionic >= 0.1.4


### PR DESCRIPTION
v0.0.9 tag [build](https://travis-ci.org/laarid/package_android-system-core/builds/189141182) is failing due to network timeout when signing versions.