### PR TITLE
libcutils: fix shlib-with-executable-stack

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,13 +44,16 @@ AM_CPPFLAGS = \
 
 AM_CFLAGS = \
 	-Wall -Werror \
+	-Wa,--noexecstack \
 	-std=gnu11
 
 AM_CXXFLAGS = \
 	-Wall -Werror \
+	-Wa,--noexecstack \
 	-std=gnu++11
 
 AM_LDFLAGS = \
+	-Wl,-z,noexecstack \
 	-Wl,--as-needed
 
 libtool_opts = \


### PR DESCRIPTION
W: libandroid-cutils0: shlib-with-executable-stack usr/lib/x86_64-linux-gnu/libandroid-cutils.so.0.15.0