### PR TITLE
libsync: install sw_sync.h as well

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,8 +24,8 @@
 #   laarid_interface_revision = 0
 m4_define([laarid_major_version], [0])
 m4_define([laarid_minor_version], [0])
-m4_define([laarid_micro_version], [17])
-m4_define([laarid_interface_revision], [0])
+m4_define([laarid_micro_version], [18])
+m4_define([laarid_interface_revision], [1])
 m4_define([laarid_api_version], [laarid_major_version.0])
 m4_define([laarid_release_number], [laarid_major_version])
 m4_define([laarid_version],

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+android-system-core (0.0.18) stretch; urgency=low
+
+  * eliminate changes between aosp by adding __LAARID__
+  * libsync: install sw_sync.h as well
+
+ -- You-Sheng Yang <vicamo@gmail.com>  Fri, 31 Mar 2017 20:53:42 +0800
+
 android-system-core (0.0.17) stretch; urgency=low
 
   * libcutils: support systemd socket activation

--- a/libsync/Android.mk
+++ b/libsync/Android.mk
@@ -16,7 +16,8 @@ lib_LTLIBRARIES += \
 
 %canon_reldir%_libandroid_sync_incdir = $(androidincdir)/sync
 %canon_reldir%_libandroid_sync_inc_HEADERS = \
-	%reldir%/include/sync/sync.h
+	%reldir%/include/sync/sync.h \
+	%reldir%/sw_sync.h
 
 bin_PROGRAMS += \
 	%reldir%/sync_test


### PR DESCRIPTION
android-drm-hwcomposer needs this header. Bump version for external
dependency as well.